### PR TITLE
Parameterize `nrpe::command` file mode

### DIFF
--- a/manifests/command.pp
+++ b/manifests/command.pp
@@ -7,6 +7,7 @@ define nrpe::command (
   $service_name = $nrpe::service_name,
   $libdir       = $nrpe::params::libdir,
   $file_group   = $nrpe::params::nrpe_files_group,
+  $file_mode    = $nrpe::command_file_default_mode,
   $sudo         = false,
   $sudo_user    = 'root',
 ) {
@@ -16,7 +17,7 @@ define nrpe::command (
     content => template('nrpe/command.cfg.erb'),
     owner   => 'root',
     group   => $file_group,
-    mode    => '0644',
+    mode    => $file_mode,
     require => Package[$package_name],
     notify  => Service[$service_name],
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,6 +53,7 @@ class nrpe (
   $ssl_log_cipher              = false,
   $ssl_log_client_cert         = false,
   $ssl_log_client_cert_details = false,
+  $command_file_default_mode   = '0644',
 ) inherits nrpe::params {
 
   if $manage_package {

--- a/spec/defines/command_spec.rb
+++ b/spec/defines/command_spec.rb
@@ -19,5 +19,9 @@ describe 'nrpe::command', type: :define do
   end
 
   it { is_expected.to compile.with_all_deps }
-  it { is_expected.to contain_file('/etc/nagios/nrpe.d/check_users.cfg') }
+  it {
+    is_expected.to contain_file('/etc/nagios/nrpe.d/check_users.cfg').with(
+      'mode' => '0644'
+    )
+  }
 end


### PR DESCRIPTION
Cherry-picked from https://github.com/pdxcat/puppet-module-nrpe/pull/64
with slight enhancement and test added by @alexjfisher 

Original PR comment.
> we stumbled upon editing file mode. our command definition contains passwords sometimes so we want to restrict access to them.