### PR TITLE
Add `supplementary_groups` parameter

### DIFF
--- a/spec/classes/nrpe_spec.rb
+++ b/spec/classes/nrpe_spec.rb
@@ -24,4 +24,10 @@ describe 'nrpe' do
 
     it { is_expected.to contain_concat_fragment('nrpe ssl fragment') }
   end
+
+  context 'when supplementary_groups set' do
+    let(:params) { { supplementary_groups: %w[foo bar] } }
+
+    it { is_expected.to contain_user('nrpe').with_groups(%w[foo bar]).that_requires('Package[nrpe]') }
+  end
 end


### PR DESCRIPTION
It can be used for adding the `nrpe_user` to extra groups. By default is
an empty array and does not change behaviour.