### PR TITLE
Major refactor into install/config/service pattern

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,0 +1,60 @@
+# @api private
+class nrpe::config
+{
+  unless $nrpe::supplementary_groups.empty {
+    user { $nrpe::nrpe_user:
+      gid    => $nrpe::nrpe_group,
+      groups => $nrpe::supplementary_groups,
+    }
+  }
+
+  concat { $nrpe::config:
+    ensure => present,
+  }
+
+  $_allow_bash_command_substitution = $nrpe::allow_bash_command_substitution ? {
+    undef   => undef,
+    default => bool2str($nrpe::allow_bash_command_substitution, '1', '0'),
+  }
+
+  concat::fragment { 'nrpe main config':
+    target  => $nrpe::config,
+    content => epp(
+      'nrpe/nrpe.cfg.epp',
+      {
+        'log_facility'                    => $nrpe::log_facility,
+        'nrpe_pid_file'                   => $nrpe::nrpe_pid_file,
+        'server_port'                     => $nrpe::server_port,
+        'server_address'                  => $nrpe::server_address,
+        'nrpe_user'                       => $nrpe::nrpe_user,
+        'nrpe_group'                      => $nrpe::nrpe_group,
+        'allowed_hosts'                   => $nrpe::allowed_hosts,
+        'dont_blame_nrpe'                 => bool2str($nrpe::dont_blame_nrpe, '1', '0'),
+        'allow_bash_command_substitution' => $_allow_bash_command_substitution,
+        'libdir'                          => $nrpe::params::libdir,
+        'command_prefix'                  => $nrpe::command_prefix,
+        'debug'                           => bool2str($nrpe::debug, '1', '0'),
+        'command_timeout'                 => $nrpe::command_timeout,
+        'connection_timeout'              => $nrpe::connection_timeout,
+      }
+    ),
+    order   => '01',
+  }
+
+  if $nrpe::ssl_cert_file_content {
+    contain nrpe::config::ssl
+  }
+
+  concat::fragment { 'nrpe includedir':
+    target  => $nrpe::config,
+    content => "include_dir=${nrpe::include_dir}\n",
+    order   => '99',
+  }
+
+  file { 'nrpe_include_dir':
+    ensure  => directory,
+    name    => $nrpe::include_dir,
+    purge   => $nrpe::purge,
+    recurse => $nrpe::recurse,
+  }
+}

--- a/manifests/config/ssl.pp
+++ b/manifests/config/ssl.pp
@@ -1,0 +1,59 @@
+# @api private
+class nrpe::config::ssl
+{
+  $_ssl_client_certs = $nrpe::ssl_client_certs ? {
+    'ask'     => '1',
+    'require' => '2',
+    default   => '0', # $ssl_client_certs = 'no'
+  }
+
+  concat::fragment { 'nrpe ssl fragment':
+    target  => $nrpe::config,
+    content => epp(
+      'nrpe/nrpe.cfg-ssl.epp',
+      {
+        'ssl_version'      => $nrpe::ssl_version,
+        'ssl_ciphers'      => $nrpe::ssl_ciphers,
+        'nrpe_ssl_dir'     => $nrpe::nrpe_ssl_dir,
+        'ssl_client_certs' => $_ssl_client_certs,
+        'ssl_logging'      => nrpe::ssl_logging(
+          $nrpe::ssl_log_startup_params,
+          $nrpe::ssl_log_remote_ip,
+          $nrpe::ssl_log_protocol_version,
+          $nrpe::ssl_log_cipher,
+          $nrpe::ssl_log_client_cert,
+          $nrpe::ssl_log_client_cert_details
+        )
+      }
+    ),
+    order   =>  '02',
+  }
+
+  file { $nrpe::nrpe_ssl_dir:
+    ensure => directory,
+    owner  => 'root',
+    group  => $nrpe::nrpe_group,
+    mode   => '0750',
+  }
+  file { "${nrpe::nrpe_ssl_dir}/ca-cert.pem":
+    ensure  => file,
+    owner   => 'root',
+    group   => $nrpe::nrpe_group,
+    mode    => '0640',
+    content => $nrpe::ssl_cacert_file_content,
+  }
+  file { "${nrpe::nrpe_ssl_dir}/nrpe-cert.pem":
+    ensure  => file,
+    owner   => 'root',
+    group   => $nrpe::nrpe_group,
+    mode    => '0640',
+    content => $nrpe::ssl_cert_file_content,
+  }
+  file { "${nrpe::nrpe_ssl_dir}/nrpe-key.pem":
+    ensure  => file,
+    owner   => 'root',
+    group   => $nrpe::nrpe_group,
+    mode    => '0640',
+    content => $nrpe::ssl_privatekey_file_content,
+  }
+}

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,0 +1,10 @@
+# @api private
+class nrpe::install
+{
+  if $nrpe::manage_package {
+    package { $nrpe::package_name:
+      ensure   => installed,
+      provider => $nrpe::provider,
+    }
+  }
+}

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -1,20 +1,37 @@
+# @summary Installs additional plugins for NRPE
 #
+# @example Install a `check_mem` plugin from a file hosted in your `site` module
+#  nrpe::plugin { 'check_mem':
+#    ensure => present,
+#    source => 'puppet:///modules/site/nrpe/check_mem',
+#  }
+#
+# @param name
+#   The name of the plugin.
+# @param ensure
+#   Whether to install or remove the plugin.
+# @param content
+#   Defines the actual content of the plugin file.  Should not be used in conjunction with `source`.
+# @param source
+#   Defines the source of the plugin file. Should not be used in conjunction with `content`.
 define nrpe::plugin (
-  Enum['present', 'absent']            $ensure       = present,
-  Optional[String[1]]                  $content      = undef,
-  Optional[Stdlib::Filesource]         $source       = undef,
-  Stdlib::Filemode                     $mode         = $nrpe::params::nrpe_plugin_file_mode,
-  Stdlib::Absolutepath                 $libdir       = $nrpe::params::libdir,
-  Variant[String[1], Array[String[1]]] $package_name = $nrpe::params::nrpe_packages,
-  String[1]                            $file_group   = $nrpe::params::nrpe_files_group,
+  Enum['present', 'absent']    $ensure  = present,
+  Optional[String[1]]          $content = undef,
+  Optional[Stdlib::Filesource] $source  = undef,
 ) {
-  file { "${libdir}/${title}":
+  include nrpe
+
+  if $ensure == 'present' {
+    if $content and $source { fail('Use one of `content` or `source`, not both') }
+    unless $content or $source { fail('One of `content` or `source` should be specified') }
+  }
+
+  file { "${nrpe::params::libdir}/${title}":
     ensure  => $ensure,
     content => $content,
     source  => $source,
     owner   => 'root',
-    group   => $file_group,
-    mode    => $mode,
-    require => Package[$package_name],
+    group   => $nrpe::params::nrpe_files_group,
+    mode    => $nrpe::params::nrpe_plugin_file_mode,
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,0 +1,8 @@
+# @api private
+class nrpe::service
+{
+  service { $nrpe::service_name:
+    ensure => running,
+    enable => true,
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -78,9 +78,6 @@
     },
     {
       "operatingsystem": "Solaris"
-    },
-    {
-      "operatingsystem": "Archlinux"
     }
   ]
 }

--- a/spec/classes/nrpe_config_spec.rb
+++ b/spec/classes/nrpe_config_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+describe 'nrpe::config' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let :facts do
+        facts
+      end
+
+      context 'by default' do
+        let(:pre_condition) { 'include nrpe' }
+
+        it { is_expected.to contain_concat('/etc/nagios/nrpe.cfg') }
+        it { is_expected.to contain_concat__fragment('nrpe main config') }
+        it { is_expected.to contain_concat__fragment('nrpe includedir') }
+        it { is_expected.to contain_file('nrpe_include_dir').with_ensure('directory') }
+      end
+
+      context 'when ssl is being used' do
+        let(:pre_condition) do
+          'class {\'nrpe\':
+            ssl_cert_file_content       => \'cert file content\',
+            ssl_privatekey_file_content => \'key file content\',
+            ssl_cacert_file_content     => \'ca cert file content\',
+           }'
+        end
+
+        it { is_expected.to contain_class('nrpe::config::ssl') }
+      end
+
+      context 'when supplementary_groups set' do
+        let(:pre_condition) do
+          'class {\'nrpe\':
+            supplementary_groups => [\'foo\',\'bar\'],
+           }'
+        end
+
+        case facts[:osfamily]
+        when 'Debian'
+          it { is_expected.to contain_user('nagios').with_groups(%w[foo bar]) }
+        else
+          it { is_expected.to contain_user('nrpe').with_groups(%w[foo bar]) }
+        end
+      end
+    end
+  end
+end

--- a/spec/classes/nrpe_config_ssl_spec.rb
+++ b/spec/classes/nrpe_config_ssl_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe 'nrpe::config::ssl' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let :facts do
+        facts
+      end
+
+      context 'when ssl is being used' do
+        let(:pre_condition) do
+          'class {\'nrpe\':
+            ssl_cert_file_content       => \'cert file content\',
+            ssl_privatekey_file_content => \'key file content\',
+            ssl_cacert_file_content     => \'ca cert file content\',
+           }'
+        end
+
+        it { is_expected.to contain_concat__fragment('nrpe ssl fragment') }
+        it { is_expected.to contain_file('/etc/nagios/nrpe-ssl').with_ensure('directory') }
+        it { is_expected.to contain_file('/etc/nagios/nrpe-ssl/ca-cert.pem').with_ensure('file').with_content('ca cert file content') }
+        it { is_expected.to contain_file('/etc/nagios/nrpe-ssl/nrpe-cert.pem').with_ensure('file').with_content('cert file content') }
+        it { is_expected.to contain_file('/etc/nagios/nrpe-ssl/nrpe-key.pem').with_ensure('file').with_content('key file content') }
+      end
+    end
+  end
+end

--- a/spec/classes/nrpe_install_spec.rb
+++ b/spec/classes/nrpe_install_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe 'nrpe::install' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let :facts do
+        facts
+      end
+
+      context 'by default' do
+        let(:pre_condition) { 'include nrpe' }
+
+        case facts[:osfamily]
+        when 'Debian'
+          it { is_expected.to contain_package('nagios-nrpe-server').with_ensure('installed') }
+          it { is_expected.to contain_package('nagios-plugins').with_ensure('installed') }
+        else
+          it { is_expected.to contain_package('nrpe').with_ensure('installed') }
+          it { is_expected.to contain_package('nagios-plugins-all').with_ensure('installed') }
+        end
+      end
+
+      context 'when manage_package is false' do
+        let(:pre_condition) { 'class {\'nrpe\': manage_package => false}' }
+
+        it { is_expected.not_to contain_package('nrpe') }
+      end
+    end
+  end
+end

--- a/spec/classes/nrpe_service_spec.rb
+++ b/spec/classes/nrpe_service_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe 'nrpe::service' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let :facts do
+        facts
+      end
+
+      context 'by default' do
+        let(:pre_condition) { 'include nrpe' }
+
+        service_name = case facts[:osfamily]
+                       when 'Debian'
+                         'nagios-nrpe-server'
+                       else
+                         'nrpe'
+                       end
+        it {
+          is_expected.to contain_service(service_name).with(
+            'ensure' => 'running',
+            'enable' => true
+          )
+        }
+      end
+    end
+  end
+end

--- a/spec/classes/nrpe_spec.rb
+++ b/spec/classes/nrpe_spec.rb
@@ -1,33 +1,17 @@
 require 'spec_helper'
 
 describe 'nrpe' do
-  let :facts do
-    { osfamily: 'RedHat',
-      architecture: 'x86_64' }
-  end
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let :facts do
+        facts
+      end
 
-  it { is_expected.to compile.with_all_deps }
-  it { is_expected.to contain_package('nrpe').with_ensure('installed') }
-  it { is_expected.to contain_package('nagios-plugins-all').with_ensure('installed') }
-  it { is_expected.to contain_service('nrpe').with_ensure('running') }
-  it { is_expected.to contain_concat('/etc/nagios/nrpe.cfg') }
-  it { is_expected.to contain_file('nrpe_include_dir').with_ensure('directory') }
-
-  context 'when manage_package is false' do
-    let(:params) { { manage_package: false } }
-
-    it { is_expected.not_to contain_package('nrpe') }
-  end
-
-  context 'when ssl is being used' do
-    let(:params) { { ssl_cert_file_content: 'cert file content' } }
-
-    it { is_expected.to contain_concat_fragment('nrpe ssl fragment') }
-  end
-
-  context 'when supplementary_groups set' do
-    let(:params) { { supplementary_groups: %w[foo bar] } }
-
-    it { is_expected.to contain_user('nrpe').with_groups(%w[foo bar]).that_requires('Package[nrpe]') }
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_class('nrpe::params') }
+      it { is_expected.to contain_class('nrpe::install') }
+      it { is_expected.to contain_class('nrpe::config').that_requires('Class[nrpe::install]') }
+      it { is_expected.to contain_class('nrpe::service').that_subscribes_to('Class[nrpe::config]') }
+    end
   end
 end

--- a/spec/defines/command_spec.rb
+++ b/spec/defines/command_spec.rb
@@ -1,27 +1,35 @@
 require 'spec_helper'
 
-describe 'nrpe::command', type: :define do
-  let(:pre_condition) { 'include nrpe' }
+describe 'nrpe::command' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let :facts do
+        facts
+      end
 
-  let(:facts) do
-    {
-      osfamily: 'Debian',
-      architecture: 'x86_64'
-    }
+      let(:title) { 'check_users' }
+      let(:params) do
+        {
+          command: 'check_users -w 5 -c 10',
+          ensure: 'present'
+        }
+      end
+
+      it { is_expected.to compile.with_all_deps }
+      case facts[:osfamily]
+      when 'Debian'
+        it {
+          is_expected.to contain_file('/etc/nagios/nrpe.d/check_users.cfg').with(
+            'mode' => '0644'
+          ).that_requires(['Package[nagios-nrpe-server]'])
+        }
+      else
+        it {
+          is_expected.to contain_file('/etc/nrpe.d/check_users.cfg').with(
+            'mode' => '0644'
+          ).that_requires(['Package[nrpe]'])
+        }
+      end
+    end
   end
-
-  let(:title) { 'check_users' }
-  let(:params) do
-    {
-      command: 'check_users -w 5 -c 10',
-      ensure: 'present'
-    }
-  end
-
-  it { is_expected.to compile.with_all_deps }
-  it {
-    is_expected.to contain_file('/etc/nagios/nrpe.d/check_users.cfg').with(
-      'mode' => '0644'
-    )
-  }
 end

--- a/spec/defines/plugin_spec.rb
+++ b/spec/defines/plugin_spec.rb
@@ -1,22 +1,27 @@
 require 'spec_helper'
 
-describe 'nrpe::plugin', type: :define do
-  let(:pre_condition) { 'include nrpe' }
+describe 'nrpe::plugin' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let :facts do
+        facts
+      end
 
-  let(:facts) do
-    {
-      osfamily: 'Debian',
-      architecture: 'x86_64'
-    }
+      let(:title) { 'check_users' }
+      let(:params) do
+        {
+          ensure: 'present',
+          source: 'puppet:///modules/profile/nrpe/check_users'
+        }
+      end
+
+      it { is_expected.to compile.with_all_deps }
+      case facts[:osfamily]
+      when 'Debian'
+        it { is_expected.to contain_file('/usr/lib/nagios/plugins/check_users').that_requires('Package[nagios-nrpe-server]') }
+      else
+        it { is_expected.to contain_file('/usr/lib64/nagios/plugins/check_users').that_requires('Package[nrpe]') }
+      end
+    end
   end
-
-  let(:title) { 'check_users' }
-  let(:params) do
-    {
-      ensure: 'present'
-    }
-  end
-
-  it { is_expected.to compile.with_all_deps }
-  it { is_expected.to contain_file('/usr/lib/nagios/plugins/check_users') }
 end


### PR DESCRIPTION
* All dependencies are now declared only in `init.pp` 
* New tests, with rspec-puppet-facts
* define type parameters that were effectively 'private' have been removed leaving just the public API.
* puppet-strings docs have been added for the defined types