### PR TITLE
Split package management into daemon and plugins components

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,6 +35,14 @@
 #   The package name or array of package names that will be installed. The default is often fine, but you may wish to set this to install extra packages like `nrpe-selinux`.
 # @param manage_package
 #   By default, set to `true` and the `nrpe` class will manage the OS package(s).
+# @param package_name_daemon
+#   The nrpe daemon package name or array of package names that will be installed. The default is often fine, but you may wish to set this to install extra packages like `nrpe-selinux`.
+# @param manage_package_daemon
+#   By default, set to `true` and the `nrpe` class will manage the OS daemon package.
+# @param package_name_plugins
+#   The plugin package name or array of package names that will be installed. The default is often fine, but you may wish to set this to install extra packages.
+# @param manage_package_plugins
+#   By default, set to `true` and the `nrpe` class will manage the OS plugins package(s).
 # @param purge
 #   When set to true, the module will purge any unmanaged commands from the NRPE includedir.
 # @param dont_blame_nrpe
@@ -107,6 +115,10 @@ class nrpe (
   Integer[0]                           $command_timeout                 = 60,
   Variant[String[1], Array[String[1]]] $package_name                    = $nrpe::params::nrpe_packages,
   Boolean                              $manage_package                  = true,
+  Variant[String[1], Array[String[1]]] $package_name_daemon             = $nrpe::params::nrpe_packages_daemon,
+  Boolean                              $manage_package_daemon           = true,
+  Variant[String[1], Array[String[1]]] $package_name_plugins            = $nrpe::params::nrpe_packages_plugins,
+  Boolean                              $manage_package_plugins          = true,
   Boolean                              $purge                           = false,
   Boolean                              $dont_blame_nrpe                 = $nrpe::params::dont_blame_nrpe,
   Nrpe::Syslogfacility                 $log_facility                    = $nrpe::params::log_facility,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,11 +38,11 @@
 # @param package_name_daemon
 #   The nrpe daemon package name or array of package names that will be installed. The default is often fine, but you may wish to set this to install extra packages like `nrpe-selinux`.
 # @param manage_package_daemon
-#   By default, set to `true` and the `nrpe` class will manage the OS daemon package.
+#   By default, set to `false`.  Have the `nrpe` class manage just the OS daemon package.  Only effective when `manage_package` is `false`.
 # @param package_name_plugins
 #   The plugin package name or array of package names that will be installed. The default is often fine, but you may wish to set this to install extra packages.
 # @param manage_package_plugins
-#   By default, set to `true` and the `nrpe` class will manage the OS plugins package(s).
+#   By default, set to `false`.  Have the `nrpe` class manage just the OS plugins package(s).  Only effective when `manage_package` is `false`.
 # @param purge
 #   When set to true, the module will purge any unmanaged commands from the NRPE includedir.
 # @param dont_blame_nrpe
@@ -116,9 +116,9 @@ class nrpe (
   Variant[String[1], Array[String[1]]] $package_name                    = $nrpe::params::nrpe_packages,
   Boolean                              $manage_package                  = true,
   Variant[String[1], Array[String[1]]] $package_name_daemon             = $nrpe::params::nrpe_packages_daemon,
-  Boolean                              $manage_package_daemon           = true,
+  Boolean                              $manage_package_daemon           = false,
   Variant[String[1], Array[String[1]]] $package_name_plugins            = $nrpe::params::nrpe_packages_plugins,
-  Boolean                              $manage_package_plugins          = true,
+  Boolean                              $manage_package_plugins          = false,
   Boolean                              $purge                           = false,
   Boolean                              $dont_blame_nrpe                 = $nrpe::params::dont_blame_nrpe,
   Nrpe::Syslogfacility                 $log_facility                    = $nrpe::params::log_facility,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,9 +3,27 @@
 # @api private
 class nrpe::install {
   if $nrpe::manage_package {
-    package { $nrpe::package_name:
-      ensure   => installed,
-      provider => $nrpe::provider,
-    }
+    ensure_packages($nrpe::package_name,
+      {
+        ensure   => installed,
+        provider => $nrpe::provider,
+      }
+    )
+  }
+  if $nrpe::manage_package_daemon {
+    ensure_packages($nrpe::package_name_daemon,
+      {
+        ensure   => installed,
+        provider => $nrpe::provider,
+      }
+    )
+  }
+  if $nrpe::manage_package_plugins {
+    ensure_packages($nrpe::package_name_plugins,
+      {
+        ensure   => installed,
+        provider => $nrpe::provider,
+      }
+    )
   }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,27 +3,25 @@
 # @api private
 class nrpe::install {
   if $nrpe::manage_package {
-    ensure_packages($nrpe::package_name,
-      {
-        ensure   => installed,
-        provider => $nrpe::provider,
-      }
-    )
+    # The classic way: install the daemon and plugins as defined by params.pp
+    $packages_to_install = $nrpe::package_name
+  } else {
+    # The selective way: install the daemon and/or plugins, as requested by your parameters.
+    if $nrpe::manage_package_daemon {
+      $_daemon_pkgs = [] + $nrpe::package_name_daemon
+    } else {
+      $_daemon_pkgs = []
+    }
+    if $nrpe::manage_package_plugins {
+      $_plugins_pkgs = [] + $nrpe::package_name_plugins
+    } else {
+      $_plugins_pkgs = []
+    }
+    $packages_to_install = $_daemon_pkgs + $_plugins_pkgs
   }
-  if $nrpe::manage_package_daemon {
-    ensure_packages($nrpe::package_name_daemon,
-      {
-        ensure   => installed,
-        provider => $nrpe::provider,
-      }
-    )
-  }
-  if $nrpe::manage_package_plugins {
-    ensure_packages($nrpe::package_name_plugins,
-      {
-        ensure   => installed,
-        provider => $nrpe::provider,
-      }
-    )
+
+  package { $packages_to_install:
+    ensure   => installed,
+    provider => $nrpe::provider,
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,77 +16,67 @@ class nrpe::params {
 
   case fact('os.family') {
     'Debian':  {
-      $libdir           = '/usr/lib/nagios/plugins'
-      $nrpe_user        = 'nagios'
-      $nrpe_group       = 'nagios'
-      $nrpe_pid_file    = '/var/run/nagios/nrpe.pid'
-      $nrpe_config      = '/etc/nagios/nrpe.cfg'
-      $nrpe_ssl_dir     = '/etc/nagios/nrpe-ssl'
-      $nrpe_include_dir = '/etc/nagios/nrpe.d'
-      $nrpe_service     = 'nagios-nrpe-server'
-      $nrpe_packages    = [
-        'nagios-nrpe-server',
-        'monitoring-plugins',
-      ]
+      $libdir                = '/usr/lib/nagios/plugins'
+      $nrpe_user             = 'nagios'
+      $nrpe_group            = 'nagios'
+      $nrpe_pid_file         = '/var/run/nagios/nrpe.pid'
+      $nrpe_config           = '/etc/nagios/nrpe.cfg'
+      $nrpe_ssl_dir          = '/etc/nagios/nrpe-ssl'
+      $nrpe_include_dir      = '/etc/nagios/nrpe.d'
+      $nrpe_service          = 'nagios-nrpe-server'
+      $nrpe_packages_daemon  = 'nagios-nrpe-server'
+      $nrpe_packages_plugins = 'monitoring-plugins'
     }
     'Solaris': {
-      $libdir           = '/opt/csw/libexec/nagios-plugins'
-      $nrpe_user        = 'nagios'
-      $nrpe_group       = 'nagios'
-      $nrpe_pid_file    = '/var/run/nrpe.pid'
-      $nrpe_config      = '/etc/opt/csw/nrpe.cfg'
-      $nrpe_ssl_dir     = '/etc/opt/csw/nrpe-ssl'
-      $nrpe_include_dir = '/etc/opt/csw/nrpe.d'
-      $nrpe_service     = 'cswnrpe'
-      $nrpe_packages    = [
-        'nrpe',
-        'nagios_plugins',
-      ]
+      $libdir                = '/opt/csw/libexec/nagios-plugins'
+      $nrpe_user             = 'nagios'
+      $nrpe_group            = 'nagios'
+      $nrpe_pid_file         = '/var/run/nrpe.pid'
+      $nrpe_config           = '/etc/opt/csw/nrpe.cfg'
+      $nrpe_ssl_dir          = '/etc/opt/csw/nrpe-ssl'
+      $nrpe_include_dir      = '/etc/opt/csw/nrpe.d'
+      $nrpe_service          = 'cswnrpe'
+      $nrpe_packages_daemon  = 'nrpe'
+      $nrpe_packages_plugins = 'nagios_plugins'
     }
     'RedHat':  {
       $libdir           = fact('os.architecture') ? {
         /x86_64/ => '/usr/lib64/nagios/plugins',
         default  => '/usr/lib/nagios/plugins',
       }
-      $nrpe_user        = 'nrpe'
-      $nrpe_group       = 'nrpe'
-      $nrpe_pid_file    = '/var/run/nrpe/nrpe.pid'
-      $nrpe_config      = '/etc/nagios/nrpe.cfg'
-      $nrpe_ssl_dir     = '/etc/nagios/nrpe-ssl'
-      $nrpe_include_dir = '/etc/nrpe.d'
-      $nrpe_service     = 'nrpe'
-      $nrpe_packages    = [
-        'nrpe',
-        'nagios-plugins-all',
-      ]
+      $nrpe_user             = 'nrpe'
+      $nrpe_group            = 'nrpe'
+      $nrpe_pid_file         = '/var/run/nrpe/nrpe.pid'
+      $nrpe_config           = '/etc/nagios/nrpe.cfg'
+      $nrpe_ssl_dir          = '/etc/nagios/nrpe-ssl'
+      $nrpe_include_dir      = '/etc/nrpe.d'
+      $nrpe_service          = 'nrpe'
+      $nrpe_packages_daemon  = 'nrpe'
+      $nrpe_packages_plugins = 'nagios-plugins-all'
     }
     'FreeBSD': {
-      $libdir           = '/usr/local/libexec/nagios'
-      $nrpe_user        = 'nagios'
-      $nrpe_group       = 'nagios'
-      $nrpe_pid_file    = '/var/run/nrpe2/nrpe2.pid'
-      $nrpe_config      = '/usr/local/etc/nrpe.cfg'
-      $nrpe_ssl_dir     = '/usr/local/etc/nrpe-ssl'
-      $nrpe_include_dir = '/usr/local/etc/nrpe.d'
-      $nrpe_service     = 'nrpe2'
-      $nrpe_packages    = [
-        'net-mgmt/nrpe',
-        'net-mgmt/nagios-plugins',
-      ]
+      $libdir                = '/usr/local/libexec/nagios'
+      $nrpe_user             = 'nagios'
+      $nrpe_group            = 'nagios'
+      $nrpe_pid_file         = '/var/run/nrpe2/nrpe2.pid'
+      $nrpe_config           = '/usr/local/etc/nrpe.cfg'
+      $nrpe_ssl_dir          = '/usr/local/etc/nrpe-ssl'
+      $nrpe_include_dir      = '/usr/local/etc/nrpe.d'
+      $nrpe_service          = 'nrpe2'
+      $nrpe_packages_daemon  = 'net-mgmt/nrpe'
+      $nrpe_packages_plugins = 'net-mgmt/nagios-plugins'
     }
     'OpenBSD': {
-      $libdir           = '/usr/local/libexec/nagios'
-      $nrpe_user        = '_nrpe'
-      $nrpe_group       = '_nrpe'
-      $nrpe_pid_file    = '/var/run/nrpe/nrpe.pid'
-      $nrpe_config      = '/etc/nrpe.cfg'
-      $nrpe_ssl_dir     = '/etc/nrpe-ssl'
-      $nrpe_include_dir = '/etc/nrpe.d'
-      $nrpe_service     = 'nrpe'
-      $nrpe_packages    = [
-        'nrpe',
-        'monitoring-plugins',
-      ]
+      $libdir                = '/usr/local/libexec/nagios'
+      $nrpe_user             = '_nrpe'
+      $nrpe_group            = '_nrpe'
+      $nrpe_pid_file         = '/var/run/nrpe/nrpe.pid'
+      $nrpe_config           = '/etc/nrpe.cfg'
+      $nrpe_ssl_dir          = '/etc/nrpe-ssl'
+      $nrpe_include_dir      = '/etc/nrpe.d'
+      $nrpe_service          = 'nrpe'
+      $nrpe_packages_daemon  = 'nrpe'
+      $nrpe_packages_plugins = 'monitoring-plugins'
     }
     'Suse':  {
       $libdir           = '/usr/lib/nagios/plugins'
@@ -96,23 +86,18 @@ class nrpe::params {
       $nrpe_service     = 'nrpe'
       case fact('os.name') {
         'SLES': {
-          $nrpe_config      = '/etc/nagios/nrpe.cfg'
-          $nrpe_ssl_dir     = '/etc/nagios/nrpe-ssl'
-          $nrpe_include_dir = '/etc/nagios/nrpe.d'
-          $nrpe_packages    = [
-            'nagios-nrpe',
-            'nagios-plugins',
-            'nagios-plugins-nrpe',
-          ]
+          $nrpe_config           = '/etc/nagios/nrpe.cfg'
+          $nrpe_ssl_dir          = '/etc/nagios/nrpe-ssl'
+          $nrpe_include_dir      = '/etc/nagios/nrpe.d'
+          $nrpe_packages_daemon  = 'nagios-nrpe'
+          $nrpe_packages_plugins = ['nagios-plugins', 'nagios-plugins-nrpe']
         }
         default:   {
-          $nrpe_config      = '/etc/nrpe.cfg'
-          $nrpe_ssl_dir     = '/etc/nrpe-ssl'
-          $nrpe_include_dir = '/etc/nrpe.d'
-          $nrpe_packages    = [
-            'nrpe',
-            'nagios-plugins-all',
-          ]
+          $nrpe_config           = '/etc/nrpe.cfg'
+          $nrpe_ssl_dir          = '/etc/nrpe-ssl'
+          $nrpe_include_dir      = '/etc/nrpe.d'
+          $nrpe_packages_daemon  = 'nrpe'
+          $nrpe_packages_plugins = 'nagios-plugins-all'
         }
       }
     }
@@ -121,20 +106,22 @@ class nrpe::params {
         /amd64|x86_64/ => '/usr/lib64/nagios/plugins',
         default        => '/usr/lib/nagios/plugins',
       }
-      $nrpe_user        = 'nagios'
-      $nrpe_group       = 'nagios'
-      $nrpe_pid_file    = '/var/run/nrpe.pid'
-      $nrpe_config      = '/etc/nagios/nrpe.cfg'
-      $nrpe_ssl_dir     = '/etc/nagios/nrpe-ssl'
-      $nrpe_include_dir = '/etc/nagios/nrpe.d'
-      $nrpe_service     = 'nrpe'
-      $nrpe_packages    = [
-        'net-analyzer/nrpe',
-        'net-analyzer/nagios-plugins',
-      ]
+      $nrpe_user             = 'nagios'
+      $nrpe_group            = 'nagios'
+      $nrpe_pid_file         = '/var/run/nrpe.pid'
+      $nrpe_config           = '/etc/nagios/nrpe.cfg'
+      $nrpe_ssl_dir          = '/etc/nagios/nrpe-ssl'
+      $nrpe_include_dir      = '/etc/nagios/nrpe.d'
+      $nrpe_service          = 'nrpe'
+      $nrpe_packages_daemon  = 'net-analyzer/nrpe'
+      $nrpe_packages_plugins = 'net-analyzer/nagios-plugins'
     }
     default:   {
     }
+  }
+
+  if $nrpe_packages_daemon and $nrpe_packages_plugins {
+    $nrpe_packages = [$nrpe_packages_daemon] + $nrpe_packages_plugins
   }
 
   $dont_blame_nrpe                 = false

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -5,7 +5,7 @@ class nrpe::service {
   if $nrpe::manage_pid_dir {
     $pid_dir = dirname($nrpe::nrpe_pid_file)
 
-    if $nrpe::manage_package {
+    if $nrpe::manage_package or $nrpe::manage_packages_daemon {
       $req_package = Package[$nrpe::package_name]
     } else {
       $req_package = undef

--- a/spec/classes/nrpe_install_spec.rb
+++ b/spec/classes/nrpe_install_spec.rb
@@ -28,6 +28,19 @@ describe 'nrpe::install' do
 
         it { is_expected.not_to contain_package('nrpe') }
       end
+
+      context 'when manage_package is false but manage_package_daemon is true' do
+        let(:pre_condition) { 'class {\'nrpe\': manage_package => false, manage_package_daemon => true}' }
+
+        case facts[:osfamily]
+        when 'Debian'
+          it { is_expected.to contain_package('nagios-nrpe-server').with_ensure('installed') }
+        when 'Gentoo'
+          it { is_expected.to contain_package('net-analyzer/nrpe').with_ensure('installed') }
+        else
+          it { is_expected.to contain_package('nrpe').with_ensure('installed') }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
#### Pull Request (PR) description
This PR splits the `package_name` and `manage_package` parameters into two extra pairs of parameters, one for the daemon and one for the plugins.  This allows more granular control of the deployments.  In the use case of "the puppet module controls the daemon package but not the plugins package", without this PR you must replicate much of the os-based choices of `manifests/params.pp` outside of the module in order to ensure that you get the right package names, when a much cleaner path is to simply capture that information in the module itself.

This is somewhat clumsy in that it introduces a duplication in the API, where you could end up with two different code paths controlling the same packages, so I'm quite open to changing patch 2 to be 'better' in terms of what's enabled/disabled, or if `manage_package` is changed to false in preparation for deprecation, or whatever seems most sane.