### PR TITLE
Fix for allow_bash_command_substitution

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -14,11 +14,6 @@ class nrpe::config
     ensure => present,
   }
 
-  $_allow_bash_command_substitution = $nrpe::allow_bash_command_substitution ? {
-    undef   => undef,
-    default => bool2str($nrpe::allow_bash_command_substitution, '1', '0'),
-  }
-
   concat::fragment { 'nrpe main config':
     target  => $nrpe::config,
     content => epp(
@@ -32,7 +27,7 @@ class nrpe::config
         'nrpe_group'                      => $nrpe::nrpe_group,
         'allowed_hosts'                   => $nrpe::allowed_hosts,
         'dont_blame_nrpe'                 => bool2str($nrpe::dont_blame_nrpe, '1', '0'),
-        'allow_bash_command_substitution' => $_allow_bash_command_substitution,
+        'allow_bash_command_substitution' => $nrpe::allow_bash_command_substitution,
         'libdir'                          => $nrpe::params::libdir,
         'command_prefix'                  => $nrpe::command_prefix,
         'debug'                           => bool2str($nrpe::debug, '1', '0'),

--- a/templates/nrpe.cfg.epp
+++ b/templates/nrpe.cfg.epp
@@ -121,7 +121,7 @@ dont_blame_nrpe=<%= $dont_blame_nrpe %>
 
 #allow_bash_command_substitution=0
 <% if $allow_bash_command_substitution { -%>
-allow_bash_command_substitution=<%= $allow_bash_command_substitution %>
+allow_bash_command_substitution=1
 <%- } -%>
 
 


### PR DESCRIPTION
# Pull Request (PR) description

Allow `allow_bash_command_substitution` to be set. 

#### This Pull Request (PR) fixes the following issues

config manifest sets the value to a string of 0 or 1, but the template expects a Boolean. Since we need to allow for undef value, best to keep it Boolean all the way through.
```
Error: Evaluation Error: Error while evaluating a Function Call, lambda: parameter 'allow_bash_command_substitution' expects a value of type Undef or Boolean, got String (file: /etc/puppetlabs/code/environments/nrpe_update/modules/nrpe/manifests/config.pp, line: 24, column: 16) on node localhost.localdomain
```