### PR TITLE
Fix `allow_bash_command_substitution`

### DIFF
--- a/spec/classes/nrpe_config_spec.rb
+++ b/spec/classes/nrpe_config_spec.rb
@@ -42,6 +42,36 @@ describe 'nrpe::config' do
           it { is_expected.to contain_user('nrpe').with_groups(%w[foo bar]) }
         end
       end
+
+      describe 'allow_bash_command_substitution' do
+        context 'by default' do
+          let(:pre_condition) { 'include nrpe' }
+
+          it { is_expected.not_to contain_concat__fragment('nrpe main config').with_content(%r{^allow_bash_command_substitution}) }
+        end
+        context 'when true' do
+          let(:pre_condition) do
+            <<-PRE_CONDITION
+            class { 'nrpe':
+              allow_bash_command_substitution => true,
+            }
+            PRE_CONDITION
+          end
+
+          it { is_expected.to contain_concat__fragment('nrpe main config').with_content(%r{^allow_bash_command_substitution=1$}) }
+        end
+        context 'when false' do
+          let(:pre_condition) do
+            <<-PRE_CONDITION
+            class { 'nrpe':
+              allow_bash_command_substitution => false,
+            }
+            PRE_CONDITION
+          end
+
+          it { is_expected.to contain_concat__fragment('nrpe main config').with_content(%r{^allow_bash_command_substitution=0$}) }
+        end
+      end
     end
   end
 end

--- a/templates/nrpe.cfg.epp
+++ b/templates/nrpe.cfg.epp
@@ -7,7 +7,7 @@
   String                         $nrpe_group,
   Array[Stdlib::Host]            $allowed_hosts,
   Enum['0','1']                  $dont_blame_nrpe,
-  Optional[Boolean]              $allow_bash_command_substitution,
+  Optional[Enum['0','1']]        $allow_bash_command_substitution,
   Stdlib::Absolutepath           $libdir,
   Optional[Stdlib::Absolutepath] $command_prefix,
   Enum['0','1']                  $debug,


### PR DESCRIPTION
Fix incorrect template data-type and add tests.