### PR TITLE
Add the ability to manage the user and group for nrpe

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -108,6 +108,11 @@ The following parameters are available in the `nrpe` class:
 * [`ssl_log_client_cert`](#-nrpe--ssl_log_client_cert)
 * [`ssl_log_client_cert_details`](#-nrpe--ssl_log_client_cert_details)
 * [`manage_pid_dir`](#-nrpe--manage_pid_dir)
+* [`manage_group`](#-nrpe--manage_group)
+* [`manage_user`](#-nrpe--manage_user)
+* [`user_comment`](#-nrpe--user_comment)
+* [`user_home_dir`](#-nrpe--user_home_dir)
+* [`user_shell`](#-nrpe--user_shell)
 * [`config`](#-nrpe--config)
 * [`include_dir`](#-nrpe--include_dir)
 * [`provider`](#-nrpe--provider)
@@ -393,6 +398,46 @@ Data type: `Boolean`
 Whether to manage the directory where the PID file should exist.
 
 Default value: `false`
+
+##### <a name="-nrpe--manage_group"></a>`manage_group`
+
+Data type: `Boolean`
+
+Whether to manage the group nrpe uses.
+
+Default value: `false`
+
+##### <a name="-nrpe--manage_user"></a>`manage_user`
+
+Data type: `Boolean`
+
+Whether to manage the user nrpe uses.
+
+Default value: `false`
+
+##### <a name="-nrpe--user_comment"></a>`user_comment`
+
+Data type: `Optional[String]`
+
+An optional string to use for the user's GECOS field.
+
+Default value: `undef`
+
+##### <a name="-nrpe--user_home_dir"></a>`user_home_dir`
+
+Data type: `Stdlib::Absolutepath`
+
+The absolute path to the home directory to use for the user.
+
+Default value: `$nrpe::params::user_home_dir`
+
+##### <a name="-nrpe--user_shell"></a>`user_shell`
+
+Data type: `Stdlib::Absolutepath`
+
+The absolute path to the shell to use for the user.
+
+Default value: `$nrpe::params::user_shell`
 
 ##### <a name="-nrpe--config"></a>`config`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -2,10 +2,34 @@
 #
 # @api private
 class nrpe::config {
-  unless $nrpe::supplementary_groups.empty {
+  if $nrpe::manage_group {
+    group { $nrpe::nrpe_group:
+      ensure => 'present',
+      system => true,
+    }
+    $group_req = Group[$nrpe::nrpe_group]
+  } else {
+    $group_req = undef
+  }
+
+  if $nrpe::manage_user {
     user { $nrpe::nrpe_user:
-      gid    => $nrpe::nrpe_group,
-      groups => $nrpe::supplementary_groups,
+      ensure  => 'present',
+      before  => Service[$nrpe::service_name],
+      comment => $nrpe::user_comment,
+      gid     => $nrpe::nrpe_group,
+      groups  => $nrpe::supplementary_groups,
+      home    => $nrpe::user_home_dir,
+      require => $group_req,
+      shell   => $nrpe::user_shell,
+      system  => true,
+    }
+  } else {
+    unless $nrpe::supplementary_groups.empty {
+      user { $nrpe::nrpe_user:
+        gid    => $nrpe::nrpe_group,
+        groups => $nrpe::supplementary_groups,
+      }
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -91,6 +91,16 @@
 #   Whether to log details of client SSL certificates.
 # @param manage_pid_dir
 #   Whether to manage the directory where the PID file should exist.
+# @param manage_group
+#   Whether to manage the group nrpe uses.
+# @param manage_user
+#   Whether to manage the user nrpe uses.
+# @param user_comment
+#   An optional string to use for the user's GECOS field.
+# @param user_home_dir
+#   The absolute path to the home directory to use for the user.
+# @param user_shell
+#   The absolute path to the shell to use for the user.
 # @param config
 #   **Private** You should not need to override this parameter.
 # @param include_dir
@@ -139,6 +149,11 @@ class nrpe (
   Array[String[1]]                     $supplementary_groups            = [],
   Boolean                              $manage_pid_dir                  = false,
   Integer[0]                           $listen_queue_size               = $nrpe::params::listen_queue_size,
+  Boolean                              $manage_user                     = false,
+  Boolean                              $manage_group                    = false,
+  Optional[String]                     $user_comment                    = undef,
+  Stdlib::Absolutepath                 $user_home_dir                   = $nrpe::params::user_home_dir,
+  Stdlib::Absolutepath                 $user_shell                      = $nrpe::params::user_shell,
 
   # Private parameters.  You shouldn't need to override these.
   Stdlib::Absolutepath                 $config                          = $nrpe::params::nrpe_config,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -28,6 +28,8 @@ class nrpe::params {
         'nagios-nrpe-server',
         'monitoring-plugins',
       ]
+      $user_home_dir    = '/var/lib/nagios'
+      $user_shell       = '/bin/false'
     }
     'Solaris': {
       $libdir           = '/opt/csw/libexec/nagios-plugins'
@@ -42,6 +44,8 @@ class nrpe::params {
         'nrpe',
         'nagios_plugins',
       ]
+      $user_home_dir    = '/var/lib/nagios'
+      $user_shell       = '/bin/false'
     }
     'RedHat':  {
       $libdir           = fact('os.architecture') ? {
@@ -59,6 +63,8 @@ class nrpe::params {
         'nrpe',
         'nagios-plugins-all',
       ]
+      $user_home_dir    = '/var/run/nrpe'
+      $user_shell       = '/sbin/nologin'
     }
     'FreeBSD': {
       $libdir           = '/usr/local/libexec/nagios'
@@ -73,6 +79,8 @@ class nrpe::params {
         'nrpe3',
         'nagios-plugins',
       ]
+      $user_home_dir    = '/var/spool/nagios'
+      $user_shell       = '/sbin/nologin'
     }
     'OpenBSD': {
       $libdir           = '/usr/local/libexec/nagios'
@@ -87,6 +95,8 @@ class nrpe::params {
         'nrpe',
         'monitoring-plugins',
       ]
+      $user_home_dir    = '/var/lib/nagios'
+      $user_shell       = '/bin/false'
     }
     'Suse':  {
       $libdir           = '/usr/lib/nagios/plugins'
@@ -115,6 +125,8 @@ class nrpe::params {
           ]
         }
       }
+      $user_home_dir    = '/var/lib/nagios'
+      $user_shell       = '/bin/false'
     }
     'Gentoo':  {
       $libdir           = fact('os.architecture') ? {
@@ -132,6 +144,8 @@ class nrpe::params {
         'net-analyzer/nrpe',
         'net-analyzer/nagios-plugins',
       ]
+      $user_home_dir    = '/dev/null'
+      $user_shell       = '/sbin/nologin'
     }
     default:   {
     }

--- a/spec/classes/nrpe_spec.rb
+++ b/spec/classes/nrpe_spec.rb
@@ -90,6 +90,98 @@ describe 'nrpe' do
 
         it { is_expected.to compile.with_all_deps }
       end
+
+      context 'when manage_group is true' do
+        let(:params) { { 'manage_group' => true } }
+
+        case facts[:osfamily]
+        when 'OpenBSD'
+          it { is_expected.to contain_group('_nrpe') }
+        when 'RedHat'
+          it { is_expected.to contain_group('nrpe') }
+        else
+          it { is_expected.to contain_group('nagios') }
+        end
+      end
+
+      context 'when manage_user is true' do
+        let(:params) { { 'manage_user' => true } }
+
+        case facts[:osfamily]
+        when 'FreeBSD'
+          it {
+            is_expected.to contain_user('nagios').
+              with_gid('nagios').
+              with_home('/var/spool/nagios').
+              with_shell('/sbin/nologin')
+          }
+        when 'Gentoo'
+          it {
+            is_expected.to contain_user('nagios').
+              with_gid('nagios').
+              with_home('/dev/null').
+              with_shell('/sbin/nologin')
+          }
+
+        when 'OpenBSD'
+          it {
+            is_expected.to contain_user('_nrpe').
+              with_gid('_nrpe').
+              with_home('/var/lib/nagios').
+              with_shell('/bin/false')
+          }
+        when 'RedHat'
+          it {
+            is_expected.to contain_user('nrpe').
+              with_gid('nrpe').
+              with_home('/var/run/nrpe').
+              with_shell('/sbin/nologin')
+          }
+        else
+          it {
+            is_expected.to contain_user('nagios').
+              with_gid('nagios').
+              with_home('/var/lib/nagios').
+              with_shell('/bin/false')
+          }
+        end
+      end
+
+      context 'when manage_group and manage_user are true' do
+        let(:params) do
+          {
+            'manage_group' => true,
+            'manage_user'  => true
+          }
+        end
+
+        case facts[:osfamily]
+        when 'OpenBSD'
+          it {
+            is_expected.to contain_group('_nrpe')
+          }
+
+          it {
+            is_expected.to contain_user('_nrpe').with_require('Group[_nrpe]')
+          }
+        when 'RedHat'
+          it {
+            is_expected.to contain_group('nrpe')
+          }
+
+          it {
+            is_expected.to contain_user('nrpe').with_require('Group[nrpe]')
+          }
+        else
+          it {
+            is_expected.to contain_group('nagios')
+          }
+
+          it {
+            is_expected.to contain_user('nagios').with_require('Group[nagios]')
+          }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
#### Pull Request (PR) description
Add the ability to manage the user and group for nrpe.  By default, this is turned off, but can easily be turned on if the user or group were not added automatically by the package.