### PR TITLE
Add amd64 as recognised Gentoo arch

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -118,8 +118,8 @@ class nrpe::params {
     }
     'Gentoo':  {
       $libdir           = fact('os.architecture') ? {
-        /x86_64/ => '/usr/lib64/nagios/plugins',
-        default  => '/usr/lib/nagios/plugins',
+        /amd64|x86_64/ => '/usr/lib64/nagios/plugins',
+        default        => '/usr/lib/nagios/plugins',
       }
       $nrpe_user        = 'nagios'
       $nrpe_group       = 'nagios'


### PR DESCRIPTION
#### Pull Request (PR) description

Some Gentoo derivative systems use amd64 instead of x86_64 for the
os.architecture fact. These systems need libdir to be set to /usr/lib64
and not /usr/lib as would otherwise be detected

#### This Pull Request (PR) fixes the following issues

n/a