### PR TITLE
Drop EOL EL 5 & 6

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -2,7 +2,6 @@
 .travis.yml:
   secure: "afO7v8HsmULSTuhn7QtSdm8C+N94sQK4MCx2eIptnjq5GH8AkajgIeo2Nv1DOP17oXBoCDwTOt6FEWEKD1P80WSA10Wa6OBKhlaoQmqKjFpSi+WNIPXLFekdXCJL5R6eLnglYHozTuIzEqB3ycxgphbim8+9fpbK4Uto3gNVDV0zVBLuyk9Se0xV9kSBwcQWpfvofx5/TOZOrxo/lDb3SbYPgqtjJYaEI91SmMom9kO9bzEn2gM2WUya+6vL4UxuzZmdlB5d8O6o1O5Vq1s2dJqoz7sY4CnMaRHhV01FQiqGtPwJ53bYYu2cAhXajL2ROPYLQTt+up32ZnCNL2zWQ4+OwTb7I/vR2uPEROTnP9eLEU2EaMXV0ajY1pP0SnD/zMMkEmcsAKRPX+yD8IsvlXri+dIJY+ftvSxhm328xGTb7Oz4MgU6m0qTgo9RMPHp59hTu4QaoKMTEmHwSFoZ/ilk47+qyNrk20wT6PAYDm28/3+9jz6YQefc1RjbNjnD7szuU0LozUVWpucjhEXGlYT58BjwIPPYu4qHehQJkS9B6/U9AIenef7Hledqh9lng918Fao3rDhUs672PmchzgN7Cwiem8ngkvtSG4SJSaATEMKiecaI1ABs0SQYoAmCapTn/eWRTbSIYNFpvfyAWG0kipAGBOtsJtmrysSFfy8="
   docker_sets:
-    - set: centos6-64
     - set: centos7-64
     - set: ubuntu1604-64
     - set: debian8-64

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,14 +26,6 @@ jobs:
       env: PUPPET_VERSION="~> 5.0" CHECK=build DEPLOY_TO_FORGE=yes
     - rvm: 2.5.3
       bundler_args: --without development release
-      env: BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_setfile=centos6-64 CHECK=beaker
-      services: docker
-    - rvm: 2.5.3
-      bundler_args: --without development release
-      env: BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_setfile=centos6-64 CHECK=beaker
-      services: docker
-    - rvm: 2.5.3
-      bundler_args: --without development release
       env: BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_setfile=centos7-64 CHECK=beaker
       services: docker
     - rvm: 2.5.3

--- a/metadata.json
+++ b/metadata.json
@@ -27,29 +27,24 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "5",
-        "6",
         "7"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "6",
         "7"
       ]
     },
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "6",
         "7"
       ]
     },
     {
       "operatingsystem": "Scientific",
       "operatingsystemrelease": [
-        "6",
         "7"
       ]
     },


### PR DESCRIPTION
Now that CentOS 5 & 6 are EOL and removed from the mirror network we have no way to test this anymore.