### PR TITLE
Remove reference to  `recurse => true` from example Class['nrpe'] definition in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ To purge unmanaged NRPE commands:
 class { 'nrpe':
   allowed_hosts => ['127.0.0.1'],
   purge         => true,
-  recurse       => true,
 }
 ```
 


### PR DESCRIPTION
#### Pull Request (PR) description

 Remove reference to `recurse => true` in README, as that option was removed in Commit 0bf84794ac98b55b5e54e72b7b3f56a129ae5b80

#### This Pull Request (PR) fixes the following issues
N/A