### PR TITLE
[nrpe/ssl] manage ssl protocols even if ssl authentication is unused

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -43,9 +43,7 @@ class nrpe::config {
     order   => '01',
   }
 
-  if $nrpe::ssl_cert_file_content {
-    contain nrpe::config::ssl
-  }
+  contain nrpe::config::ssl
 
   concat::fragment { 'nrpe includedir':
     target  => $nrpe::config,

--- a/manifests/config/ssl.pp
+++ b/manifests/config/ssl.pp
@@ -30,31 +30,33 @@ class nrpe::config::ssl {
     order   => '02',
   }
 
-  file { $nrpe::nrpe_ssl_dir:
-    ensure => directory,
-    owner  => 'root',
-    group  => $nrpe::nrpe_group,
-    mode   => '0750',
-  }
-  file { "${nrpe::nrpe_ssl_dir}/ca-cert.pem":
-    ensure  => file,
-    owner   => 'root',
-    group   => $nrpe::nrpe_group,
-    mode    => '0640',
-    content => $nrpe::ssl_cacert_file_content,
-  }
-  file { "${nrpe::nrpe_ssl_dir}/nrpe-cert.pem":
-    ensure  => file,
-    owner   => 'root',
-    group   => $nrpe::nrpe_group,
-    mode    => '0640',
-    content => $nrpe::ssl_cert_file_content,
-  }
-  file { "${nrpe::nrpe_ssl_dir}/nrpe-key.pem":
-    ensure  => file,
-    owner   => 'root',
-    group   => $nrpe::nrpe_group,
-    mode    => '0640',
-    content => $nrpe::ssl_privatekey_file_content,
+  if $_ssl_client_certs != '0' {
+    file { $nrpe::nrpe_ssl_dir:
+      ensure => directory,
+      owner  => 'root',
+      group  => $nrpe::nrpe_group,
+      mode   => '0750',
+    }
+    file { "${nrpe::nrpe_ssl_dir}/ca-cert.pem":
+      ensure  => file,
+      owner   => 'root',
+      group   => $nrpe::nrpe_group,
+      mode    => '0640',
+      content => $nrpe::ssl_cacert_file_content,
+    }
+    file { "${nrpe::nrpe_ssl_dir}/nrpe-cert.pem":
+      ensure  => file,
+      owner   => 'root',
+      group   => $nrpe::nrpe_group,
+      mode    => '0640',
+      content => $nrpe::ssl_cert_file_content,
+    }
+    file { "${nrpe::nrpe_ssl_dir}/nrpe-key.pem":
+      ensure  => file,
+      owner   => 'root',
+      group   => $nrpe::nrpe_group,
+      mode    => '0640',
+      content => $nrpe::ssl_privatekey_file_content,
+    }
   }
 }

--- a/templates/nrpe.cfg-ssl.epp
+++ b/templates/nrpe.cfg-ssl.epp
@@ -30,11 +30,12 @@ ssl_version=<%= $ssl_version %>
 #ssl_cipher_list=ALL:!aNULL:!eNULL:!SSLv2:!LOW:!EXP:!RC4:!MD5:@STRENGTH
 ssl_cipher_list=<%= $ssl_ciphers.join(':') %>
 
+<% if $ssl_client_certs != '0' { -%>
 # SSL Certificate and Private Key Files
-
 ssl_cacert_file=<%= $nrpe_ssl_dir%>/ca-cert.pem
 ssl_cert_file=<%= $nrpe_ssl_dir%>/nrpe-cert.pem
 ssl_privatekey_file=<%= $nrpe_ssl_dir%>/nrpe-key.pem
+<% } end -%>
 
 # SSL USE CLIENT CERTS
 # This options determines client certificate usage.


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
I want to be able to configure ssl protocol settings even if I don't use ssl cert authentication.
SSL directive can be included all time even if daemon is started with no-ssl flag.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
