### PR TITLE
Update puppetlabs-concat and fix tests on Oracle Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ This module has been documented with [puppet-strings](https://github.com/puppetl
  * This module requires the EPEL repositories to be enabled
  * This module currently does not manage the firewall rules
 
+### Oracle Linux
+
+* This module requires the EPEL and Optional Updates repositories to be enabled
+
 ### Solaris
 
  * This module depends on OpenCSW packages

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 4.1.0 < 8.0.0"
+      "version_requirement": ">= 4.1.0 < 10.0.0"
     },
     {
       "name": "puppetlabs/stdlib",

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -4,6 +4,11 @@ require 'voxpupuli/acceptance/spec_helper_acceptance'
 
 configure_beaker do |host|
   install_package(host, 'epel-release') if fact_on(host, 'os.name') == 'CentOS'
+  if fact_on(host, 'os.name') == 'OracleLinux'
+    ver = fact_on(host, 'os.release.major')
+    install_package(host, "oracle-epel-release-el#{ver}")
+    on host, "yum-config-manager --enable ol#{ver}_optional_latest"
+  end
 end
 
 shared_examples 'an idempotent resource' do


### PR DESCRIPTION

#### Pull Request (PR) description

The primary goal of this PR was to update the puppetlabs-concat dependency to permit the use of puppetlabs-stdlib 9.x.

Recently added tests for Oracle Linux 7 were failing. The necessary packages needed EPEL to be available, but even when this was added the installation of `nagios-plugins-all` failed due to dependency errors. I tried Oracle Linux 7, 8 and 9, so I'm not sure whether this module can support Oracle Linux easily.

If Oracle Linux support is important, there are more details from the failed CI runs in our fork (see [here for 7](https://github.com/mysociety/puppet-nrpe/actions/runs/6350077657) and [here for 8 and 9](https://github.com/mysociety/puppet-nrpe/actions/runs/6349472004)).